### PR TITLE
Replace 'ws' with 'uws'

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
 		"randomstring": "^1.0.3",
 		"request": "^2.51.0",
 		"strftime": "^0.8.2",
-		"ws": "^0.7.1"
+		"uws": "^8.14.0"
 	},
 	"devDependencies": {
 		"mocha": "^2.1.0",
 		"mockery": "^1.4.0",
 		"chai": "^1.10.0",
-		"sinon": "^1.12.2"
+		"sinon": "^1.12.2",
+		"ws": "^0.7.1"
 	},
 	"engines": {
 		"node": ">=0.12.0",

--- a/server.js
+++ b/server.js
@@ -565,7 +565,7 @@ module.exports = function (onInit) {
 		});
 		
 		// Give server WebSocket powers
-		var WebSocketServer = require('ws').Server;
+		var WebSocketServer = require('uws').Server;
 		var wss = new WebSocketServer({
 			server: server,
 			verifyClient: function (info, cb) {


### PR DESCRIPTION
```
npm install
```

Tests use 'ws' library not in server mode, but in client mode and also use one feature that is not supported by 'uws'. Therefore I left the same 'ws' version for tests. For the actual stream-server logic 'uws' should work well as a drop in replacement.