### PR TITLE
When continued variable is explicitly false, delay is set to be 250ms

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -30,7 +30,8 @@ var config = {
 	// Notification action period -- clients are given a randomly chosen delay within this time
 	// period before they should act upon the notification, so that we don't DDoS ourselves
 	globalTopicsDelayPeriod: 1800 * 1000,
-	continuedDelayDefault: 3 * 1000,
+	notContinuedDelay: 250,
+	defaultDelay: 3 * 1000,
 	continuedDelay: 30 * 1000,
 	statsD: {
 		host: ''

--- a/config/default.js
+++ b/config/default.js
@@ -30,9 +30,9 @@ var config = {
 	// Notification action period -- clients are given a randomly chosen delay within this time
 	// period before they should act upon the notification, so that we don't DDoS ourselves
 	globalTopicsDelayPeriod: 1800 * 1000,
-	notContinuedDelay: 250,
 	defaultDelay: 3 * 1000,
 	continuedDelay: 30 * 1000,
+	notContinuedDelay: 250,
 	statsD: {
 		host: ''
 	}

--- a/config/test.json
+++ b/config/test.json
@@ -4,5 +4,5 @@
 	"redis": {
 		"prefix": ""
 	},
-	"continuedDelayDefault": 0
+	"defaultDelay": 0
 }

--- a/server.js
+++ b/server.js
@@ -60,10 +60,15 @@ module.exports = function (onInit) {
 			clearTimeout(timeout);
 			delete continuedTimeouts[topic];
 		}
-		
-		continuedTimeouts[topic] = setTimeout(fn,
-			continued ? config.get('continuedDelay') : config.get('continuedDelayDefault')
-		);
+		if (continued) {
+			continuedTimeouts[topic] = setTimeout(fn, config.get('continuedDelay'));
+		} 
+		else if (continued == false) {
+			continuedTimeouts[topic] = setTimeout(fn, config.get('notContinuedDelay'));
+		} 
+		else {
+			continuedTimeouts[topic] = setTimeout(fn, config.get('defaultDelay'));
+		}	
 	}
 	
 	/**


### PR DESCRIPTION
Addresses [Issue # 130](https://github.com/zotero/dataserver/issues/130)

When a message has `continued=false`, delay is only 250ms